### PR TITLE
fix - replace NaN values for all fields to None

### DIFF
--- a/nornir_table_inventory/plugins/inventory/table.py
+++ b/nornir_table_inventory/plugins/inventory/table.py
@@ -140,7 +140,7 @@ class FlatDataInventory:
         hosts = Hosts()
 
         for host_dict in self.hosts_list:
-            if str(host_dict['name']) != "nan":
+            if not _empty(host_dict['name']):
                 hosts[host_dict['name']] = _get_host_obj(host_dict)
 
         return Inventory(hosts=hosts, groups=groups, defaults=defaults)

--- a/nornir_table_inventory/plugins/inventory/table.py
+++ b/nornir_table_inventory/plugins/inventory/table.py
@@ -94,6 +94,8 @@ def _get_host_obj(data: Dict[str, Any]) -> Host:
     username = data.get("username")
     password = data.get("password")
     platform = data.get("platform")
+    if name:
+        name = str(name)
     if hostname:
         hostname = str(hostname) if str(hostname) != "nan" else None
     if port:

--- a/nornir_table_inventory/plugins/inventory/table.py
+++ b/nornir_table_inventory/plugins/inventory/table.py
@@ -142,6 +142,9 @@ class FlatDataInventory:
         for host_dict in self.hosts_list:
             if not _empty(host_dict['name']):
                 hosts[host_dict['name']] = _get_host_obj(host_dict)
+            else:
+                logger.error(f"HOST name is empty for data : {host_dict}")
+                raise Exception('HOST name must not be empty')
 
         return Inventory(hosts=hosts, groups=groups, defaults=defaults)
 

--- a/nornir_table_inventory/plugins/inventory/table.py
+++ b/nornir_table_inventory/plugins/inventory/table.py
@@ -94,8 +94,6 @@ def _get_host_obj(data: Dict[str, Any]) -> Host:
     username = data.get("username")
     password = data.get("password")
     platform = data.get("platform")
-    if name:
-        name = str(name) if str(name) != "nan" else None
     if hostname:
         hostname = str(hostname) if str(hostname) != "nan" else None
     if port:
@@ -134,7 +132,8 @@ class FlatDataInventory:
         hosts = Hosts()
 
         for host_dict in self.hosts_list:
-            hosts[host_dict['name']] = _get_host_obj(host_dict)
+            if str(host_dict['name']) != "nan":
+                hosts[host_dict['name']] = _get_host_obj(host_dict)
 
         return Inventory(hosts=hosts, groups=groups, defaults=defaults)
 

--- a/nornir_table_inventory/plugins/inventory/table.py
+++ b/nornir_table_inventory/plugins/inventory/table.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 
 
 def _empty(x: Any):
-    """Checks if x is a NaN (not a number) or None"""
-    return x is None or (isinstance(x, float) and isnan(x))
+    """Checks if x is a NaN (not a number) or None/empty string"""
+    return x is None or (isinstance(x, float) and isnan(x)) or x == ""
 
 
 def _get_connection_options(data: Dict[str, Any]) -> Dict[str, ConnectionOptions]:

--- a/nornir_table_inventory/plugins/inventory/table.py
+++ b/nornir_table_inventory/plugins/inventory/table.py
@@ -1,5 +1,6 @@
 import csv
 import logging
+from math import isnan
 from typing import Any, Dict, List
 
 import pandas as pd
@@ -13,6 +14,11 @@ from nornir.core.inventory import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _empty(x: Any):
+    """Checks if x is a NaN (not a number) or None"""
+    return x is None or (isinstance(x, float) and isnan(x))
 
 
 def _get_connection_options(data: Dict[str, Any]) -> Dict[str, ConnectionOptions]:
@@ -35,7 +41,7 @@ def _get_host_data(data: Dict[str, Any]) -> Dict[str, Any]:
     netmiko_prefix = 'netmiko_'
     for k, v in data.items():
         if (k not in no_data_fields) and (netmiko_prefix not in k):
-            resp_data[k] = v if str(v) != "nan" else None
+            resp_data[k] = v if not _empty(v) else None
     return resp_data
 
 
@@ -74,7 +80,7 @@ def _get_host_netmiko_options(data: Dict[str, Any]) -> Dict[str, Any]:
                     extra_opts[new_k] = True
             else:
                 # if the value is nan,convert it to None
-                if str(v)=='nan':
+                if _empty(v):
                     extra_opts[new_k] = None
                 else:
                     extra_opts[new_k] = v
@@ -97,15 +103,15 @@ def _get_host_obj(data: Dict[str, Any]) -> Host:
     if name:
         name = str(name)
     if hostname:
-        hostname = str(hostname) if str(hostname) != "nan" else None
+        hostname = str(hostname) if not _empty(hostname) else None
     if port:
-        port = int(port) if str(port) != "nan" else None
+        port = int(port) if not _empty(port) else None
     if username:
-        username = str(username) if str(username) != "nan" else None
+        username = str(username) if not _empty(username) else None
     if password:
-        password = str(password) if str(password) != "nan" else None
+        password = str(password) if not _empty(password) else None
     if platform:
-        platform = str(platform) if str(platform) != "nan" else None
+        platform = str(platform) if not _empty(platform) else None
 
     return Host(
         name=name,

--- a/nornir_table_inventory/plugins/inventory/table.py
+++ b/nornir_table_inventory/plugins/inventory/table.py
@@ -35,7 +35,7 @@ def _get_host_data(data: Dict[str, Any]) -> Dict[str, Any]:
     netmiko_prefix = 'netmiko_'
     for k, v in data.items():
         if (k not in no_data_fields) and (netmiko_prefix not in k):
-            resp_data[k] = v
+            resp_data[k] = v if str(v) != "nan" else None
     return resp_data
 
 
@@ -95,17 +95,17 @@ def _get_host_obj(data: Dict[str, Any]) -> Host:
     password = data.get("password")
     platform = data.get("platform")
     if name:
-        name = str(name)
+        name = str(name) if str(name) != "nan" else None
     if hostname:
-        hostname = str(hostname)
+        hostname = str(hostname) if str(hostname) != "nan" else None
     if port:
-        port = int(port)
+        port = int(port) if str(port) != "nan" else None
     if username:
-        username = str(username)
+        username = str(username) if str(username) != "nan" else None
     if password:
-        password = str(password)
+        password = str(password) if str(password) != "nan" else None
     if platform:
-        platform = str(platform)
+        platform = str(platform) if str(platform) != "nan" else None
 
     return Host(
         name=name,


### PR DESCRIPTION
Dear @jiujing ,
Your latest change was a breaking one for me as I was relying on the old behavior where NaN values got into the inventory. Now I'd like to complete the new behavior for all values. In my understanding the only mandatory values in Nornir inventory are the name and hostname. All others are optional as those can come from groups and defaults.
I added this behavior for hostname too because on this level we should let Nornir to error out on wrong input. I say that a bit biased because I rely on the fact that name may be empty when I deal with switch stacks and the name field is empty for me. That's kinda sign for the code to skip those hosts. I incorporated that logic here so rows with empty "name" will be ignored which is fine as those would mix up anyway.

I added helper function _empty() to check variable more reliably for NaN value. str(var)=="nan" can give us false value when user tries to use "nan" as string.
